### PR TITLE
Update experience locations and Construx role title

### DIFF
--- a/content/experience/full/auckland_vip.tex
+++ b/content/experience/full/auckland_vip.tex
@@ -1,7 +1,7 @@
 \noindent
 \textbf{Research Software Engineer Intern} \hfill \textit{Feb 2026 -- Jun 2026}\\
 \noindent
-\textit{Empathic Computing Laboratory, University of Auckland (Top 100 QS, Remote)}\\[0.05em]
+\textit{Empathic Computing Laboratory, University of Auckland (Top 100 QS)} \hfill \textit{Auckland, New Zealand (Remote)}\\[0.05em]
 
 \begin{itemize}[leftmargin=*, itemsep=0.3em, topsep=0.01em]
 

--- a/content/experience/full/construx.tex
+++ b/content/experience/full/construx.tex
@@ -1,7 +1,7 @@
 \noindent
-\textbf{System Architect \& Software Engineer (Part-time)} \hfill \textit{Jan 2025 -- Present}\\
+\textbf{Software Engineer (Part-time)} \hfill \textit{Jan 2025 -- Present}\\
 \noindent
-\textit{Construx Technologies Pvt. Ltd}\\[0.05em]
+\textit{Construx Technologies Pvt. Ltd} \hfill \textit{Full Remote}\\[0.05em]
 
 \begin{itemize}[leftmargin=*, itemsep=0.3em, topsep=0.01em]
 

--- a/content/experience/full/isa_internship.tex
+++ b/content/experience/full/isa_internship.tex
@@ -1,7 +1,7 @@
 \noindent
 \textbf{Software Engineer Intern} \hfill \textit{Dec 2024 -- May 2025}\\
 \noindent
-\textit{Information Systems Associates (Pvt) Ltd --- Aviation Technology Company}\\[0.05em]
+\textit{Information Systems Associates (Pvt) Ltd --- Aviation Technology Company} \hfill \textit{Colombo, Sri Lanka (On-site)}\\[0.05em]
 
 \begin{itemize}[leftmargin=*, itemsep=0.3em, topsep=0.01em]
 

--- a/content/experience/medium/auckland_vip.tex
+++ b/content/experience/medium/auckland_vip.tex
@@ -1,6 +1,6 @@
 \noindent\\
 \textbf{Software Engineer Intern (Part-time)} \hfill \textit{Feb 2026 -- Present}\\
-\textit{Empathic Computing Laboratory, University of Auckland  (Remote)}\\[0.05em]
+\textit{Empathic Computing Laboratory, University of Auckland} \hfill \textit{Auckland, New Zealand (Remote)}\\[0.05em]
 \begin{itemize}[leftmargin=*, itemsep=0.1em, topsep=0.1em]
     \item \textbf{Engineered} a robust Android-based data pipeline for mobile and wearable platforms to handle high-volume, real-time physiological data streams.
     \item \textbf{Implemented} background service architectures on smartphones and watches to ensure consistent, low-latency data collection in production environments.

--- a/content/experience/medium/construx.tex
+++ b/content/experience/medium/construx.tex
@@ -1,6 +1,6 @@
 \noindent
-\textbf{System Architect \& Software Engineer (Part-time)} \hfill \textit{Jan 2025 -- Present}\\
-\textit{Construx Technologies Pvt. Ltd}\\[0.05em]
+\textbf{Software Engineer (Part-time)} \hfill \textit{Jan 2025 -- Present}\\
+\textit{Construx Technologies Pvt. Ltd} \hfill \textit{Full Remote}\\[0.05em]
 \begin{itemize}[leftmargin=*, itemsep=0.1em, topsep=0.1em]
     \item \textbf{Architected} a full-stack payroll system (React, Node.js, Express) ensuring statutory compliance for EPF/ETF and APIT/PAYE automation.
     \item \textbf{Integrated} and managed a \textbf{Supabase} backend, orchestrating relational schemas for employees, organizations, and salary revisions.

--- a/content/experience/medium/isa_internship.tex
+++ b/content/experience/medium/isa_internship.tex
@@ -1,7 +1,7 @@
 \noindent
 \textbf{Software Engineer Intern} \hfill \textit{Dec 2024 -- May 2025}\\
 \noindent
-\textit{Information Systems Associates (Pvt) Ltd --- Aviation Technology(Airarabia)}\\[0.05em]
+\textit{Information Systems Associates (Pvt) Ltd --- Aviation Technology(Airarabia)} \hfill \textit{Colombo, Sri Lanka (On-site)}\\[0.05em]
 \begin{itemize}[leftmargin=*, itemsep=0.3em, topsep=0.01em]
     \item \textbf{AeroOrder --- Order Management Microservice (Java 17, Spring Boot, Gradle)}
     \begin{itemize}[leftmargin=1.5em, itemsep=0.1em]

--- a/content/experience/short/auckland_vip_short.tex
+++ b/content/experience/short/auckland_vip_short.tex
@@ -1,6 +1,6 @@
 \noindent
 \textbf{Research Software Engineer Intern} \hfill \textit{Feb 2026 -- Jun 2026}\\
-\textit{Empathic Computing Laboratory, University of Auckland (Remote)}
+\textit{Empathic Computing Laboratory, University of Auckland} \hfill \textit{Auckland, New Zealand (Remote)}
 \begin{itemize}[leftmargin=*, itemsep=0.05em, topsep=0.1em]
     \item Developed an Android digital phenotyping pipeline for mobile-wearable platforms to collect longitudinal behavioral and physiological data.
     \item Captured mobility, sleep, and usage patterns via smartphone and smartwatch sensor data collection.

--- a/content/experience/short/construx.tex
+++ b/content/experience/short/construx.tex
@@ -1,6 +1,6 @@
 \noindent
-\textbf{System Architect \& Software Engineer (Part-time)} \hfill \textit{Jan 2025 -- Present}\\
-\textit{Construx Technologies Pvt. Ltd}
+\textbf{Software Engineer (Part-time)} \hfill \textit{Jan 2025 -- Present}\\
+\textit{Construx Technologies Pvt. Ltd} \hfill \textit{Full Remote}
 \begin{itemize}[leftmargin=*, itemsep=0.05em, topsep=0.1em]
     \item Architected a React and Node.js payroll system, enforcing statutory tax and EPF compliance.
     \item Developed core REST APIs and integrated Supabase for scalable employee data management.

--- a/content/experience/short/isa_internship.tex
+++ b/content/experience/short/isa_internship.tex
@@ -1,5 +1,5 @@
 \textbf{Software Engineer Intern} \hfill \textit{Dec 2024 – May 2025} \\
-\textit{Information Systems Associates (Pvt) Ltd — Aviation Technology Company}
+\textit{Information Systems Associates (Pvt) Ltd — Aviation Technology Company} \hfill \textit{Colombo, Sri Lanka (On-site)}
 
 \begin{itemize}[leftmargin=*]
     \item Contributed to both the modernization of a legacy PSS (AeroMart) and the development of its microservices-based successor (AeroOrder), focusing on seamless integration and backward compatibility.

--- a/content/experience/short/isa_internship_short.tex
+++ b/content/experience/short/isa_internship_short.tex
@@ -1,6 +1,6 @@
 \noindent
 \textbf{Software Engineer Intern} \hfill \textit{Dec 2024 -- May 2025}\\
-\textit{Information Systems Associates (Pvt) Ltd --- Aviation Technology}
+\textit{Information Systems Associates (Pvt) Ltd --- Aviation Technology} \hfill \textit{Colombo, Sri Lanka (On-site)}
 \begin{itemize}[leftmargin=*, itemsep=0.2em, topsep=0.1em]
     \item \textbf{AeroOrder --- Order Management Microservice (Java 17, Spring Boot, Gradle)}
     \begin{itemize}[leftmargin=1.5em, itemsep=0.05em]

--- a/content/experience/tailored/isa_internship_backend.tex
+++ b/content/experience/tailored/isa_internship_backend.tex
@@ -1,5 +1,5 @@
 \textbf{Software Engineer Intern (Backend Focus)} \hfill \textit{Dec 2024 – May 2025} \\
-\textit{Information Systems Associates (Pvt) Ltd — Aviation Technology Company}
+\textit{Information Systems Associates (Pvt) Ltd — Aviation Technology Company} \hfill \textit{Colombo, Sri Lanka (On-site)}
 
 \begin{itemize}[leftmargin=*]
     \item Engineered a distributed, high-throughput unique ID generator for Passenger Name Records (PNRs) using a Kafka-backed pool model, ensuring uniqueness and security across scaled instances.

--- a/content/experience/tailored/isa_internship_devops.tex
+++ b/content/experience/tailored/isa_internship_devops.tex
@@ -1,5 +1,5 @@
 \textbf{Software Engineer Intern (DevOps Focus)} \hfill \textit{Dec 2024 – May 2025} \\
-\textit{Information Systems Associates (Pvt) Ltd — Aviation Technology Company}
+\textit{Information Systems Associates (Pvt) Ltd — Aviation Technology Company} \hfill \textit{Colombo, Sri Lanka (On-site)}
 
 \begin{itemize}[leftmargin=*]
     \item Resolved critical production issues, including Kafka consumer lag and offset resetting, by implementing robust shutdown hooks and enhanced retry mechanisms to improve fault tolerance and system recoverability.

--- a/content/experience/tailored/isa_internship_fullstack.tex
+++ b/content/experience/tailored/isa_internship_fullstack.tex
@@ -1,5 +1,5 @@
 \textbf{Software Engineer Intern (Fullstack Focus)} \hfill \textit{Dec 2024 – May 2025} \\
-\textit{Information Systems Associates (Pvt) Ltd — Aviation Technology Company}
+\textit{Information Systems Associates (Pvt) Ltd — Aviation Technology Company} \hfill \textit{Colombo, Sri Lanka (On-site)}
 
 \begin{itemize}[leftmargin=*]
     \item Engineered a distributed, high-throughput unique ID generator for Passenger Name Records (PNRs) using a Kafka-backed pool model, ensuring uniqueness and security across scaled instances while adhering to aviation domain standards.


### PR DESCRIPTION
This submission updates the experience section files across the CV repository to include accurate location and working model details as requested by the user. Specifically, it:\n1. Appends 'Colombo, Sri Lanka (On-site)' to the ISA internship organization name.\n2. Standardizes 'Auckland, New Zealand (Remote)' for the Empathic Computing Laboratory internship.\n3. Changes the Construx Technologies role title from 'System Architect & Software Engineer' to 'Software Engineer' and appends 'Full Remote' to the organization name. These changes apply to the short, medium, full, and tailored variants to ensure consistency across all generated resume profiles.

---
*PR created automatically by Jules for task [17464212169648620790](https://jules.google.com/task/17464212169648620790) started by @UchihaIthachi*